### PR TITLE
Fix unreadable input field with latest Messenger update

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -101,6 +101,7 @@ input::-webkit-input-placeholder {
 /* input bar */
 ._4rv3 {
 	border-top-color: rgba(255, 255, 255, .1) !important;
+	background-color: #1e1e1e;
 }
 /* make static stickers slightly more readable */
 /*


### PR DESCRIPTION
The latest update to Messenger.com's styling made the input field unreadable as it now has an explicitly set 95% white color as background.

Before and after screenshots attached.

![screenshot from 2016-01-27 23-06-45](https://cloud.githubusercontent.com/assets/315346/12630156/67303be4-c54b-11e5-97af-3aa21b45a3d7.png)
![screenshot from 2016-01-27 23-07-00](https://cloud.githubusercontent.com/assets/315346/12630157/6733cd4a-c54b-11e5-9b05-dbdae1c5123d.png)

This fixes #2.
