### PR TITLE
Investigate getting chat colours working

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -54,8 +54,11 @@ input::-webkit-input-placeholder {
 ._hh7 {
 	background-color: #2d2d30;
 }
-._hh7, ._hh7 a, ._nd_ ._hh7, ._nd_ ._hh7 a {
+._hh7, ._hh7 a, ._nd_ ._hh7 {
 	color: #ddd;
+}
+._nd_ ._hh7 a {
+	color: inherit;
 }
 ._hh7:active, ._-5k ._hh7, ._hh7>span>a:hover {
 	background-color: #333;
@@ -68,11 +71,11 @@ input::-webkit-input-placeholder {
 	background-color: #005599;
 }
 /* own message: chat colours */
-._nd_ ._hh7[style*="color"], ._nd_ ._hh7[style*="color"] a {
+._nd_ ._hh7[style*="color"] {
 	color: black !important;
 }
-._nd_ ._hh7[style*="rgb(118, 70, 255)"] *,
-._nd_ ._hh7[style*="rgb(250, 60, 76)"] * {
+._nd_ ._hh7[style*="rgb(118, 70, 255)"],
+._nd_ ._hh7[style*="rgb(250, 60, 76)"] {
 	color: white !important;
 }
 /* emoji-only messages */

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -68,8 +68,8 @@ input::-webkit-input-placeholder {
 	background-color: #003377;
 }
 /* own message: chat colours */
-._nd_ ._hh7[style*="color"] {
-	color: #1e1e1e !important;
+._nd_ ._hh7[style*="color"], ._nd_ ._hh7[style*="color"] a {
+	color: black !important;
 }
 /* emoji-only messages */
 ._hh7._2f5r, ._hh7._2f5r:active, ._-5k ._hh7._2f5r {

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -71,6 +71,10 @@ input::-webkit-input-placeholder {
 ._nd_ ._hh7[style*="color"], ._nd_ ._hh7[style*="color"] a {
 	color: black !important;
 }
+._nd_ ._hh7[style*="rgb(118, 70, 255)"] *,
+._nd_ ._hh7[style*="rgb(250, 60, 76)"] * {
+	color: white !important;
+}
 /* emoji-only messages */
 ._hh7._2f5r, ._hh7._2f5r:active, ._-5k ._hh7._2f5r {
 	background-color: transparent;

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -67,6 +67,10 @@ input::-webkit-input-placeholder {
 ._nd_ ._hh7:active, ._nd_._-5k ._hh7, ._nd_ ._hh7>span>a:hover {
 	background-color: #003377;
 }
+/* own message: chat colours */
+._nd_ ._hh7[style*="color"] {
+	color: #1e1e1e !important;
+}
 /* emoji-only messages */
 ._hh7._2f5r, ._hh7._2f5r:active, ._-5k ._hh7._2f5r {
 	background-color: transparent;

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -52,24 +52,24 @@ input::-webkit-input-placeholder {
 }
 /* message */
 ._hh7 {
-	background-color: #2d2d30 !important;
+	background-color: #2d2d30;
 }
-._hh7, ._hh7 a {
-	color: #ddd !important;
+._hh7, ._hh7 a, ._nd_ ._hh7, ._nd_ ._hh7 a {
+	color: #ddd;
 }
 ._hh7:active, ._-5k ._hh7, ._hh7>span>a:hover {
-	background-color: #333 !important;
+	background-color: #333;
 }
 /* own message */
 ._nd_ ._hh7 {
-	background-color: #004488 !important;
+	background-color: #004488;
 }
 ._nd_ ._hh7:active, ._nd_._-5k ._hh7, ._nd_ ._hh7>span>a:hover {
-	background-color: #003377 !important;
+	background-color: #003377;
 }
 /* emoji-only messages */
-._hh7._2f5r, ._-5k ._hh7._2f5r {
-	background-color: transparent !important;
+._hh7._2f5r, ._hh7._2f5r:active, ._-5k ._hh7._2f5r {
+	background-color: transparent;
 }
 /* link info */
 ._5i_d {

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -64,8 +64,8 @@ input::-webkit-input-placeholder {
 ._nd_ ._hh7 {
 	background-color: #004488;
 }
-._nd_ ._hh7:active, ._nd_._-5k ._hh7, ._nd_ ._hh7>span>a:hover {
-	background-color: #003377;
+._nd_ ._hh7:active, ._nd_._-5k ._hh7 {
+	background-color: #005599;
 }
 /* own message: chat colours */
 ._nd_ ._hh7[style*="color"], ._nd_ ._hh7[style*="color"] a {


### PR DESCRIPTION
As most know, Facebook, out of their sheer genius, decided that chat colours would be a _brilliant_ idea.

This style specifically changes the bubble colour of the user's own messages to a darker blue than Messenger/iOS blue. However, this overrides chat colours.

We should keep in mind that many of the possible chat colours also have too much contrast on a dark background as well.
### Non-solutions
- `brightness` and `contrast` filters. These affect text as well, not just the background colour.
### Possible solutions
- Delivery receipts are coloured using the `hue-rotate` CSS filter, we could do a similar thing. I don't fancy the idea of a large stylesheet just to have chat colours work though.
- Override each chat colour with our own with CSS. See the above point.
- Look into Facebook's JS and see if it's possible to change the colours there. This would involve a separate userscript, one which I would prefer to be optional.
- Wait until Facebook makes the whole chat colour thing saner on their end. Probably not happening.
- Do nothing, because chat colours were a silly idea in the first place.
