### PR TITLE
Support for colored chat bubbles

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -64,7 +64,7 @@ input::-webkit-input-placeholder {
 ._nd_ ._hh7 {
 	background-color: #004488;
 }
-._nd_ ._hh7:active, ._nd_._-5k ._hh7, ._nd_ ._hh7>span>a:hover {
+._nd_ ._hh7:active, ._nd_._-5k ._hh7 {
 	background-color: #003377;
 }
 /* emoji-only messages */

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -51,20 +51,20 @@ input::-webkit-input-placeholder {
 	color: #eee !important;
 }
 /* message */
-._hh7 {
+._29_7 ._hh7, ._29_7._-5k ._hh7 {
 	background-color: #2d2d30;
 }
-._hh7, ._hh7 a {
+._29_7 ._hh7, ._29_7 ._hh7 a {
 	color: #ddd;
 }
-._hh7:active, ._-5k ._hh7, ._hh7>span>a:hover {
+._29_7 ._hh7:active, ._-5k ._hh7, ._29_7 ._hh7>span>a:hover {
 	background-color: #333;
 }
 /* own message */
-._nd_ ._hh7 {
+._o46._nd_ ._hh7 {
 	background-color: #004488;
 }
-._nd_ ._hh7:active, ._nd_._-5k ._hh7 {
+._o46._nd_ ._hh7:active, ._o46._nd_._-5k ._hh7 {
 	background-color: #003377;
 }
 /* emoji-only messages */

--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -52,20 +52,20 @@ input::-webkit-input-placeholder {
 }
 /* message */
 ._hh7 {
-	background-color: #2d2d30 !important;
+	background-color: #2d2d30;
 }
 ._hh7, ._hh7 a {
-	color: #ddd !important;
+	color: #ddd;
 }
 ._hh7:active, ._-5k ._hh7, ._hh7>span>a:hover {
-	background-color: #333 !important;
+	background-color: #333;
 }
 /* own message */
 ._nd_ ._hh7 {
-	background-color: #004488 !important;
+	background-color: #004488;
 }
 ._nd_ ._hh7:active, ._nd_._-5k ._hh7, ._nd_ ._hh7>span>a:hover {
-	background-color: #003377 !important;
+	background-color: #003377;
 }
 /* emoji-only messages */
 ._hh7._2f5r, ._-5k ._hh7._2f5r {


### PR DESCRIPTION
I have found simply removing the `!important` part of the message bubble color queries styles works to support the new chat color feature. This overrides default styling and thus preserves dark mode, but is overriden by special chat colors.
