### PR TITLE
Hotfix: make embedded code dark

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -322,4 +322,11 @@ div._4-i2, div._5a8u, ._4t2a {
 ._17cj ._2ze8, ._17cj ._cen, ._5sr7 {
 	color: rgba(255, 255, 255, .6) !important;
 }
+
+/* Change embedded code with dark theme */
+._wu0 {
+    background: #111111;
+	border: 1px solid #252525;
+}
+
 }


### PR DESCRIPTION
This might be required to be touched up to suit the theme better. However, fun fact: Messenger allows for embedded code.

These code snippet messages start with triple back tick and the language you are using (like markdown). 

Example: Writing this in a messenger box:

`````` markdown
   ```c
   /* Hello World Program */
   #include <stdlib.h>
   int main(){
      printf("Hello World!");
      return 0;
   }
``````

Appears as:
![screenshot_2016-05-23_19-03-12](https://cloud.githubusercontent.com/assets/11262664/15465650/05444590-2119-11e6-9730-a27d0b0809e8.png)
