### PR TITLE
Make selected conversation emoji dark

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -255,6 +255,12 @@ input::-webkit-input-placeholder {
 	filter: invert(1);
 }
 
+/* chosen emoji */
+._4rlt {
+	background-color: #333 !important;
+	color: #666 !important;
+}
+
 /* messenger dialogs, very important */
 ._4-hz, ._4eby, ._4jgp ._4jgu {
 	background-color: #222 !important;


### PR DESCRIPTION
The class denoting the chosen emoji for a conversation was untouched, so I gave it some darker colours. Feel free to change the colours if you feel they don't quite work.

Before:
![before](https://cloud.githubusercontent.com/assets/13175844/15805905/48c45dbc-2b7a-11e6-89ea-a948d9b2537a.JPG)

After:
![after](https://cloud.githubusercontent.com/assets/13175844/15805913/6846eb96-2b7a-11e6-8338-b22c1ab144e8.JPG)
