### PR TITLE
Remove white border around messages

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -64,6 +64,9 @@ input::-webkit-input-placeholder {
 ._hh7 a {
 	color: inherit !important;
 }
+._hh7._aol {
+	border-color: transparent;
+}
 ._29_7 ._hh7:active, ._-5k ._hh7, ._29_7 ._hh7>span>a:hover {
 	background-color: #333;
 }


### PR DESCRIPTION
A white border started appearing around messages for me today. This fixes that.

![messenger-dark-theme-fix](https://cloud.githubusercontent.com/assets/5691865/24181872/04053f76-0f12-11e7-9215-8abc6f6e0bf1.gif)
