### PR TITLE
Prevent unnecessary scrollbar from showing in composer

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -146,6 +146,10 @@ input::-webkit-input-placeholder {
 	background-color: #1e1e1e !important;
 	border-top-color: rgba(255, 255, 255, .1) !important;
 }
+/* prevent useless scrollbar from showing in composer */
+._2swd._kmc {
+	padding-bottom: 9px !important;
+}
 /* make static stickers slightly more readable */
 /*
 ._2poz[style*="sticker"] {


### PR DESCRIPTION
When the window is resized below a width of 1282 pixels, a scrollbar appears in the message text input (composer). Said scrollbar allows you to scroll down by 1 pixel, i.e. it's quite unnecessary. "Type a message…" also feels slightly too close for comfort to the buttons below it, so this fixes that also.

I should point out that the scrollbar appearing is not an issue caused by this theme, and appears to be a "bug" with Messenger itself.

![dark-messenger-scrollbar-fix](https://cloud.githubusercontent.com/assets/5691865/25618201/577646ea-2f89-11e7-805f-55547dda0d5c.gif)

```css
._2swd._kmc {
	padding-bottom: 9px !important;
}
```

Also, the `!important` *is* important:

![2017-05-02 22 17 11 developer_tools_-_httpswww messenger com](https://cloud.githubusercontent.com/assets/5691865/25618243/9161c424-2f89-11e7-8794-84840e88d421.png)
