### PR TITLE
Remove white border from Messenger/Facebook icons

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -168,6 +168,32 @@ input::-webkit-input-placeholder {
 	border-color: #282828 !important;
 }
 
+/* Messenger icon */
+._2poo {
+	border-radius: 50%;
+	box-shadow: inset 0 0 0 3px #0084ff;
+}
+/* Facebook icon */
+._2pop {
+	border-radius: 50%;
+	box-shadow: inset 0 0 0 3px #929292;
+}
+/* Messenger/Facebook icon - Draw dark grey border over white border */
+._2pon:after {
+	content: "";
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	right: -1px;
+	bottom: -1px;
+	border-radius: 50%;
+	border: 2px solid #282828;
+}
+/* Messenger/Facebook icons within the main wrapper */
+._4sp8 ._2pon:after {
+	border-color: #1e1e1e;
+}
+
 /* convo info, user list */
 ._4_j5, ._5l37 {
 	background-color: #282828 !important;


### PR DESCRIPTION
*Partially copied from my comment on #15*

---

![dark-messenger-icon-borders](https://cloud.githubusercontent.com/assets/5691865/25624400/9740b612-2f9c-11e7-851a-2199cb3cd620.gif)
```css
/* Messenger icon */
._2poo {
	border-radius: 50%;
	box-shadow: inset 0 0 0 3px #0084ff;
}
/* Facebook icon */
._2pop {
	border-radius: 50%;
	box-shadow: inset 0 0 0 3px #929292;
}
/* Messenger/Facebook icon - Draw dark grey border over white border */
._2pon:after {
	content: "";
	position: absolute;
	top: -1px;
	left: -1px;
	right: -1px;
	bottom: -1px;
	border-radius: 50%;
	border: 2px solid #282828;
}
/* Messenger/Facebook icons within the main wrapper */
._4sp8 ._2pon:after {
	border-color: #1e1e1e;
}
```

# Colors used

|  | Color | Description |
|------------------------------------------------------|---------|-------------|
| ![Messenger icon](https://cloud.githubusercontent.com/assets/5691865/25659350/bd6868fe-304a-11e7-8fe9-8e70b9b069d7.png) | `#0084ff` | The blue of the Messenger icon |
| ![Facebook icon](https://cloud.githubusercontent.com/assets/5691865/25659392/eb113254-304a-11e7-992f-ca5981f0e34d.png) | `#929292` | The grey of the Facebook icon |
| ![#282828](https://hatscripts.com/placeholder.svg?c=282828) | `#282828` | The dark grey background color of the convo info |
| ![#1e1e1e](https://hatscripts.com/placeholder.svg?c=1e1e1e) | `#1e1e1e` | The dark grey background color of the main wrapper |

# Other examples

Messenger/Facebook icons which appear next to received messages:
![message example](https://cloud.githubusercontent.com/assets/5691865/25631433/bf36ff16-2fb3-11e7-8f7c-c7cc305673fd.png)

Messenger/Facebook icons shown in search results:
![search results example](https://cloud.githubusercontent.com/assets/5691865/25621789/bc98ee22-2f95-11e7-8950-c7f3202377c9.png)