### PR TITLE
Make highlighted search results legible

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -51,6 +51,12 @@ input::-webkit-input-placeholder {
 ._33p7 {
 	background-color: rgba(30, 30, 30, 0.9)	!important;
 }
+/* highlighted search results */
+.__in {
+	background-color: rgba(0, 0, 0, 0.3);
+	box-shadow: 2px 0 rgba(0, 0, 0, 0.3), -2px 0 rgba(0, 0, 0, 0.3);
+	padding: 1px 0 2px 0;
+}
 /* event plan banner */
 ._3nta {
 	background-color: #2d2d30 !important;


### PR DESCRIPTION
Regardless of the chat bubble colour.

![dark-messenger-search-result-highlights](https://user-images.githubusercontent.com/5691865/36952038-ac0aabbc-205e-11e8-99db-a7bc0292ecea.gif)
