### PR TITLE
Change nickname color

### DIFF
--- a/fb-messenger-dark.css
+++ b/fb-messenger-dark.css
@@ -500,3 +500,9 @@ div._4-i2, div._5a8u {
 	color: rgba(255, 255, 255, .6) !important;
 }
 }
+
+/* nicknames gray rather than blue */
+
+._3oh- > div > a {
+    color: #ddd !important;
+}


### PR DESCRIPTION
Makes nicknames gray to better fit the overall style. They used to be gray in the past, but some FB update broke it probably.
!["Screenshot"](https://i.imgur.com/te2jYWF.png)