### PR TITLE
Fix thumb up sticker background colour

### DIFF
--- a/fb-messenger-dark.user.css
+++ b/fb-messenger-dark.user.css
@@ -223,6 +223,9 @@ input::-webkit-input-placeholder {
 	-webkit-filter: brightness(75%);
 	filter: brightness(75%);
 }
+._576q > svg > rect {
+	fill: #282828;
+}
 /* facebook-removed messages et al */
 ._4sp8 .uiBoxYellow {
 	background-color: #662;


### PR DESCRIPTION
we were seeing this:
![image](https://user-images.githubusercontent.com/9259833/62000850-a87f2a80-b096-11e9-9e0e-ee620dc7e0df.png)

so we need a rule to fix the background color using the [css fill property.](https://stackoverflow.com/a/11293812) so that it looks like:
![image](https://user-images.githubusercontent.com/9259833/62000859-de241380-b096-11e9-9087-8a255c5d9810.png)
