### PR TITLE
Patch white reply decorator

### DIFF
--- a/fb-messenger-dark.user.css
+++ b/fb-messenger-dark.user.css
@@ -129,6 +129,9 @@ input::-webkit-input-placeholder {
 ._4k7a {
 	color: #aaa !important;
 }
+._3egs {
+	background: transparent !important;
+}
 /* link info, platform attachment, game leaderboard */
 ._5i_d, ._5ssp, ._4ea2 {
 	border-color: rgba(255, 255, 255, .1) !important;


### PR DESCRIPTION
Recent changes broke the reply decorator, resulting in horrible white rectangles within conversations where someone replies to something (regardless of direction, group members etc.) This small patch fixes this. Attached example of the incorrectly styled reply decorator.

<img width="186" alt="Screen Shot 2019-11-13 at 9 03 01 PM" src="https://user-images.githubusercontent.com/6403471/68799762-07be7600-0659-11ea-8a1f-ac107f05d0c6.png">
