### PR TITLE
Fix the "Type a message..." prompt message color

### DIFF
--- a/fb-messenger-dark.user.css
+++ b/fb-messenger-dark.user.css
@@ -521,7 +521,8 @@ div._4-i2, div._5a8u {
 /* stuff that should be grey */
 ._ih3, ._3tl0, ._3tl1 ._10w4, ._497p, ._3x6v, ._2v6o, ._3tky, ._5rh4, ._5qsj, ._jf4 ._jf3, ._5i_d .__6m, ._2y8z,
 ._4g0h, ._3xcx, ._225b, ._3q35, ._2r2v, ._2n1t, ._1n-e, ._3eus, ._2wy4, ._1u5d ._1u5k, ._3ggt,
-._17cj ._2ze8, ._17cj ._cen, ._5sr7, ._4nw0 {
+._17cj ._2ze8, ._17cj ._cen, ._5sr7, ._4nw0, ._1p1v {
 	color: rgba(255, 255, 255, .6) !important;
+	-webkit-text-fill-color: rgba(255, 255, 255, .6) !important;
 }
 }


### PR DESCRIPTION
Currently, the "Type a message..." prompt is black (on dark grey with the theme) and illegible. This fixes it so that that text is light grey (so that it is legible).