### PR TITLE
updated chatbox label text colour

### DIFF
--- a/fb-messenger-dark.user.css
+++ b/fb-messenger-dark.user.css
@@ -35,8 +35,8 @@ input::-webkit-input-placeholder {
 	color: #888 !important;
 }
 ._kmc._7kpg ._1p1t {
-	color: #888;
-	-webkit-text-fill-color: #888;
+	color: #888 !important;
+	-webkit-text-fill-color: #888 !important;
 }
 
 /* top bars */

--- a/fb-messenger-dark.user.css
+++ b/fb-messenger-dark.user.css
@@ -34,6 +34,10 @@ input::-moz-placeholder {
 input::-webkit-input-placeholder {
 	color: #888 !important;
 }
+._kmc._7kpg ._1p1t {
+	color: #888;
+	-webkit-text-fill-color: #888;
+}
 
 /* top bars */
 ._36ic, ._673w {


### PR DESCRIPTION
I found the way to fix the chatbox label colour the way it should be corrected (matching the proper fb dark theme)

![image](https://user-images.githubusercontent.com/10705539/97783436-e0efab80-1beb-11eb-83ed-e2a6ef595527.png)
